### PR TITLE
Reorder docs.rs target list so more common targets come first

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "known-folders"
-version = "1.0.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.0.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"
@@ -36,10 +36,10 @@ features = ["markdown_deps_updated", "html_root_url_updated"]
 rustdoc-args = ["--cfg", "docsrs"]
 targets = [
   # Tier 1
-  "i686-pc-windows-gnu",
-  "i686-pc-windows-msvc",
-  "x86_64-pc-windows-gnu",
   "x86_64-pc-windows-msvc",
+  "x86_64-pc-windows-gnu",
+  "i686-pc-windows-msvc",
+  "i686-pc-windows-gnu",
   # Tier 2
   #  "aarch64-pc-windows-msvc",
   #  "i586-pc-windows-msvc",

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-known-folders = "1.0.0"
+known-folders = "1.0.1"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! [Known Folders]: https://learn.microsoft.com/en-us/windows/win32/shell/known-folders
 
-#![doc(html_root_url = "https://docs.rs/known-folders/1.0.0")]
+#![doc(html_root_url = "https://docs.rs/known-folders/1.0.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, windows))]


### PR DESCRIPTION
Prepare v1.0.1 release.