### PR TITLE
Address code quality issues identified in Zcash audit

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -94,7 +94,7 @@ pub fn get_known_folder_path(known_folder: KnownFolder) -> Option<PathBuf> {
         )
     } {
         S_OK => {
-            let path_ptr = guard.as_pwstr();
+            let path_ptr = guard.as_pcwstr();
 
             // SAFETY: on success, the out pointer is guaranteed to be a valid,
             // NUL-terminated wide string.
@@ -107,9 +107,10 @@ pub fn get_known_folder_path(known_folder: KnownFolder) -> Option<PathBuf> {
                 usize::try_from(len).ok()?
             };
 
-            // SAFETY: `path_ptr` is valid for `len` bytes in a single string
-            // allocation, per windows-sys APIs. `lstrlenW` returns `i32` on
-            // 64-bit platforms. The `match` below guarantees the size of the
+            // SAFETY: `path_ptr` is valid for `len` "characters" in a single
+            // string allocation, per windows-sys APIs. "Characters" are `WCHAR`
+            // values. Additionally, `lstrlenW` returns `i32` on 64-bit
+            // platforms. The `match` below guarantees the size of the
             // allocation is no larger than `isize::MAX`.
             let path = unsafe {
                 match isize::try_from(len) {

--- a/src/win.rs
+++ b/src/win.rs
@@ -119,6 +119,9 @@ pub fn get_known_folder_path(known_folder: KnownFolder) -> Option<PathBuf> {
                     Ok(_) | Err(_) => return None,
                 };
 
+                // NOTE: this slice must go out of scope before `guard` above is
+                // dropped. This invariant holds since the guard is constructed
+                // outside the scope of this `match` block.
                 slice::from_raw_parts(path_ptr, len)
             };
 

--- a/src/win/ffi.rs
+++ b/src/win/ffi.rs
@@ -11,7 +11,7 @@
 use core::ffi::c_void;
 use core::ptr;
 
-use windows_sys::core::PWSTR;
+use windows_sys::core::{PCWSTR, PWSTR};
 use windows_sys::Win32::System::Com::CoTaskMemFree;
 
 pub struct Guard(PWSTR);
@@ -39,7 +39,7 @@ impl Guard {
 
     /// Access the inner wide string.
     #[must_use]
-    pub fn as_pwstr(&self) -> PWSTR {
+    pub fn as_pcwstr(&self) -> PCWSTR {
         self.0
     }
 }
@@ -58,6 +58,10 @@ impl Drop for Guard {
         // > The calling process is responsible for freeing this resource
         // > once it is no longer needed by calling `CoTaskMemFree`, whether
         // > `SHGetKnownFolderPath` succeeds or not.
+        //
+        // Additionally, `CoTaskMemFree` has no effect if passed `NULL`, so
+        // there is no issue if some future refactor creates a pathway where
+        // `Guard` could be dropped before `SHGetKnownFolderPath` is called.
         unsafe {
             CoTaskMemFree(ptr);
         }


### PR DESCRIPTION
- Return a const `PCWSTR` from `ffi::Guard` to pass to `lstrlenW` to be consistent with the `&self` receiver.
- Fixup an error in a comment relating to interpreting the value returned by `lstrlenW`.
- Add additional safety documentation to `impl Drop for ffi::Guard`.

Fixes #16.

cc @str4d