### PR TITLE
Prepare v1.1.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "known-folders"
-version = "1.0.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.1.0" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-known-folders = "1.0.1"
+known-folders = "1.1.0"
 ```
 
 Then resolve well-known directories like this:
@@ -43,6 +43,7 @@ cargo run --example get_profile_dir
 ## Implementation
 
 known-folders-rs binds directly to `Win32` using [`windows_sys`].
+Semver-incompatible `windows_sys` upgrades can be made in minor releases.
 
 [`windows_sys`]: https://crates.io/crates/windows-sys
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! [Known Folders]: https://learn.microsoft.com/en-us/windows/win32/shell/known-folders
 
-#![doc(html_root_url = "https://docs.rs/known-folders/1.0.1")]
+#![doc(html_root_url = "https://docs.rs/known-folders/1.1.0")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, windows))]


### PR DESCRIPTION
Only non-dependency changes are:

- #29 
- #30