### PR TITLE
Remove deprecated windows-2019 CI image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, windows-2019, windows-2022]
+        os:
+          - windows-latest
+          - windows-2022
+          - windows-2025
     env:
       RUSTFLAGS: -D warnings
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Per an email I received from GitHub:

> Hello there,
>
> The Windows Server 2019 runner image will be fully unsupported by June 30, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Windows Server 2019. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:
>
> * June 3 13:00-21:00 UTC
> * June 10 13:00-21:00 UTC
> * June 17 13:00-21:00 UTC
> June 24 13:00-21:00 UTC
>
> **What you need to do**
>
> Jobs using the `windows-2019` YAML workflow label should be updated to `windows-2022`, `windows-2025` or `windows-latest`. You can always get up-to-date information on our tools by reading about the software in the [runner images repository](https://github.com/actions/runner-images). Please contact GitHub [Support](https://support.github.com/request?tags=dotcom-contact-params) if you run into any problems or need help.