### PR TITLE
Set up crates.io trusted publishing and harden GitHub workflows

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -18,6 +18,8 @@ jobs:
   ruby:
     name: Audit Ruby Dependencies
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # required to checkout repository
 
     steps:
       - name: Checkout repository
@@ -42,6 +44,8 @@ jobs:
         checks:
           - advisories
           - bans licenses sources
+    permissions:
+      contents: read # required to checkout repository
 
     # Prevent sudden announcement of a new advisory from failing ci:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
@@ -53,7 +57,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/audit@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
 
       - name: Generate Cargo.lock
         run: |
@@ -79,6 +85,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@e639db99335bc9038abc0e066dfcd72e23d26fb4 # v0.3.0
+        uses: zizmorcore/zizmor-action@135698455da5c3b3e55f73f4419e481ab68cdd95 # v0.4.1
         with:
           persona: "pedantic"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,10 +9,11 @@ name: CI
       - trunk
   schedule:
     - cron: "0 0 * * WED"
-permissions: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read # needed to checkout contents
 jobs:
   build:
     name: Build
@@ -48,7 +49,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
 
@@ -99,7 +100,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: "1.60.0"
 
@@ -150,7 +151,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/build-and-test@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
 
@@ -198,8 +199,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/lint-and-format@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
+          components: rustfmt, clippy
           toolchain: stable
 
       - name: Check formatting
@@ -236,7 +238,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Node.js runtime
-        uses: actions/setup-node@v6.1.0
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,145 @@
+---
+name: Publish
+"on":
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  crates-io:
+    name: Publish to crates.io
+    if: github.event.created == true
+    runs-on: ubuntu-latest
+    environment:
+      name: crates-io-publish
+    permissions:
+      actions: read # required to inspect CI workflow run status
+      contents: read # required to checkout repository
+      id-token: write # required for trusted publishing to crates.io
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
+      RUST_BACKTRACE: 1
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Configure ephemeral Rust homes
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Use per-job temporary directories and avoid cross-run caches.
+          mkdir -p "${RUNNER_TEMP}/cargo-home" "${RUNNER_TEMP}/rustup-home"
+          echo "CARGO_HOME=${RUNNER_TEMP}/cargo-home" >> "$GITHUB_ENV"
+          echo "RUSTUP_HOME=${RUNNER_TEMP}/rustup-home" >> "$GITHUB_ENV"
+
+      - name: Validate release tag
+        shell: bash
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release tag '$TAG' does not match vX.Y.Z"
+            exit 1
+          fi
+
+      - name: Install Rust toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup set profile minimal
+          rustup toolchain install stable --no-self-update
+          rustup default stable
+          rustc -Vv
+          cargo -V
+
+      - name: Ensure Cargo.toml version matches tag
+        shell: bash
+        env:
+          TAG_VERSION: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${TAG_VERSION#v}"
+          CARGO_VERSION="$(sed -n 's/^version = "\([0-9][0-9.]*\)".*/\1/p' Cargo.toml | head -n1)"
+          if [[ -z "$CARGO_VERSION" ]]; then
+            echo "failed to parse crate version from Cargo.toml"
+            exit 1
+          fi
+          if [[ "$TAG_VERSION" != "$CARGO_VERSION" ]]; then
+            echo "tag version '$TAG_VERSION' does not match crate version '$CARGO_VERSION'"
+            exit 1
+          fi
+
+      - name: Wait for CI on tagged commit
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+          CI_WORKFLOW_NAME: CI
+          POLL_INTERVAL_SECONDS: 20
+          MAX_WAIT_SECONDS: 10800
+        run: |
+          set -euo pipefail
+
+          deadline="$(( $(date +%s) + MAX_WAIT_SECONDS ))"
+          run_list=(
+            gh run list
+            --repo "${REPO}"
+            --workflow "${CI_WORKFLOW_NAME}"
+            --commit "${SHA}"
+            --limit 50
+          )
+
+          while true; do
+            ci_count="$(
+              "${run_list[@]}" --json status --jq 'length'
+            )"
+
+            if [[ "${ci_count}" -eq 0 ]]; then
+              echo "no '${CI_WORKFLOW_NAME}' workflow runs found yet for ${SHA}; waiting..."
+            else
+              pending_count="$(
+                "${run_list[@]}" --json status --jq '[.[] | select(.status != "completed")] | length'
+              )"
+              if [[ "${pending_count}" -gt 0 ]]; then
+                echo "${pending_count} '${CI_WORKFLOW_NAME}' runs pending for ${SHA}; waiting..."
+              else
+                non_success_count="$(
+                  "${run_list[@]}" --json conclusion --jq '[.[] | select(.conclusion != "success")] | length'
+                )"
+                if [[ "${non_success_count}" -eq 0 ]]; then
+                  echo "all '${CI_WORKFLOW_NAME}' runs for ${SHA} completed successfully."
+                  break
+                fi
+                echo "'${CI_WORKFLOW_NAME}' is not green for ${SHA}:"
+                "${run_list[@]}" --json conclusion,url --jq '.[] | select(.conclusion != "success") | "- \(.url) => \(.conclusion)"'
+                exit 1
+              fi
+            fi
+
+            if [[ "$(date +%s)" -ge "${deadline}" ]]; then
+              echo "timed out waiting for '${CI_WORKFLOW_NAME}' to complete for ${SHA}"
+              exit 1
+            fi
+            sleep "${POLL_INTERVAL_SECONDS}"
+          done
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+
+      - name: Publish crate
+        shell: bash
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,7 +40,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: artichoke/setup-rust/rustdoc@68e0ebb3b406970de1cc2ca807797c9156a198a7 # v2.0.1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: nightly
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features


### PR DESCRIPTION
## Summary
- add a publish workflow for crates.io trusted publishing using GitHub OIDC
- replace archived Rust setup actions with `dtolnay/rust-toolchain` and pin `actions/setup-node`
- add workflow concurrency controls and permission rationale comments so zizmor pedantic passes
- update zizmor action pin in the audit workflow

## Validation
- `zizmor --persona pedantic .github/workflows/*.yaml`

## Ops
- created GitHub environment `crates-io-publish` via `gh api` for this repository
