### PR TITLE
Bump known-folders to v1.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "known-folders"
-version = "1.4.0" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.4.1" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-known-folders = "1.4.0"
+known-folders = "1.4.1"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@
 //!
 //! [Known Folders]: https://learn.microsoft.com/en-us/windows/win32/shell/known-folders
 
-#![doc(html_root_url = "https://docs.rs/known-folders/1.4.0")]
+#![doc(html_root_url = "https://docs.rs/known-folders/1.4.1")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, windows))]


### PR DESCRIPTION
## Summary
- bump crate version from `1.4.0` to `1.4.1` in `Cargo.toml`
- update `html_root_url` in `src/lib.rs` to match the new crate version

## Validation
- version metadata update only
