### PR TITLE
Fix rustdoc build and prepare v1.4.2 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "known-folders"
-version = "1.4.1" # remember to set `html_root_url` in `src/lib.rs`.
+version = "1.4.2" # remember to set `html_root_url` in `src/lib.rs`.
 authors = ["Ryan Lopopolo <rjl@hyperbo.la>"]
 license = "Apache-2.0 OR MIT"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-known-folders = "1.4.1"
+known-folders = "1.4.2"
 ```
 
 Then resolve well-known directories like this:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,6 @@
 //
 // This approach is borrowed from tokio.
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_alias))]
 
 //! Retrieves the full path of a known folder identified by the folder's
 //! **KNOWNFOLDERID** on Windows systems using `SHGetKnownFolderPath` and the
@@ -52,7 +51,7 @@
 //!
 //! [Known Folders]: https://learn.microsoft.com/en-us/windows/win32/shell/known-folders
 
-#![doc(html_root_url = "https://docs.rs/known-folders/1.4.1")]
+#![doc(html_root_url = "https://docs.rs/known-folders/1.4.2")]
 
 // Ensure code blocks in `README.md` compile
 #[cfg(all(doctest, windows))]


### PR DESCRIPTION
## Summary
- remove the stale docsrs doc_alias feature gate that now fails under -D warnings
- bump the crate and docs metadata from 1.4.1 to 1.4.2
- update the README dependency snippet for the point release

## Verification
- rustup update nightly
- cargo +nightly test
- RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links --cfg docsrs" cargo +nightly doc --no-deps
- cargo package --allow-dirty