### PR TITLE
[codex] Fail closed when prettier is unavailable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -245,8 +245,11 @@ jobs:
       - name: Install npm dependencies
         run: npm ci --ignore-scripts
 
+      - name: Verify prettier is installed locally
+        run: npm ls prettier --depth=0
+
       - name: Format with prettier
-        run: npm run lint:text
+        run: npm exec -- prettier --check '**/*'
 
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -246,7 +246,7 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Format with prettier
-        run: ./node_modules/.bin/prettier --check '**/*'
+        run: npm run lint:text
 
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -242,8 +242,11 @@ jobs:
         with:
           node-version: "lts/*"
 
+      - name: Install npm dependencies
+        run: npm ci --ignore-scripts
+
       - name: Format with prettier
-        run: npx prettier --check '**/*'
+        run: ./node_modules/.bin/prettier --check '**/*'
 
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -243,13 +243,10 @@ jobs:
           node-version: "lts/*"
 
       - name: Install npm dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Verify prettier is installed locally
-        run: npm ls prettier --depth=0
+        run: npm ci
 
       - name: Format with prettier
-        run: npm exec -- prettier --check '**/*'
+        run: npx prettier --check '**/*'
 
       - name: Install uv
         uses: astral-sh/setup-uv@681c641aba71e4a1c380be3ab5e12ad51f415867 # v7.1.6

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,19 @@ require 'shellwords'
 require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
+def prettier_bin!
+  prettier = %w[prettier prettier.cmd]
+             .map { |bin| File.expand_path(File.join('node_modules', '.bin', bin), __dir__) }
+             .find { |path| File.file?(path) }
+  return prettier if prettier
+
+  abort 'prettier is not installed. Run `npm install` before invoking this task.'
+end
+
+def run_prettier(*args)
+  sh Shellwords.join([prettier_bin!, *args])
+end
+
 task default: %i[format lint]
 
 desc 'Lint sources'
@@ -48,7 +61,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npx prettier --write "**/*"'
+    run_prettier('--write', '**/*')
   end
 end
 
@@ -63,7 +76,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npx prettier --write "**/*"'
+    run_prettier('--write', '**/*')
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,13 @@ require 'shellwords'
 require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
+def run_prettier(*args)
+  prettier_installed = system('npm', 'ls', 'prettier', '--depth=0', out: File::NULL, err: File::NULL)
+  abort 'prettier is not installed. Run `npm install` before invoking this task.' unless prettier_installed
+
+  sh Shellwords.join(['npm', 'exec', '--', 'prettier', *args])
+end
+
 task default: %i[format lint]
 
 desc 'Lint sources'
@@ -48,7 +55,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npm run format:text'
+    run_prettier('--write', '**/*')
   end
 end
 
@@ -63,7 +70,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    sh 'npm run format:text'
+    run_prettier('--write', '**/*')
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,19 +5,6 @@ require 'shellwords'
 require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
-def prettier_bin!
-  prettier = %w[prettier prettier.cmd]
-             .map { |bin| File.expand_path(File.join('node_modules', '.bin', bin), __dir__) }
-             .find { |path| File.file?(path) }
-  return prettier if prettier
-
-  abort 'prettier is not installed. Run `npm install` before invoking this task.'
-end
-
-def run_prettier(*args)
-  sh Shellwords.join([prettier_bin!, *args])
-end
-
 task default: %i[format lint]
 
 desc 'Lint sources'
@@ -61,7 +48,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    run_prettier('--write', '**/*')
+    sh 'npm run format:text'
   end
 end
 
@@ -76,7 +63,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    run_prettier('--write', '**/*')
+    sh 'npm run format:text'
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,13 +5,6 @@ require 'shellwords'
 require 'bundler/audit/task'
 require 'rubocop/rake_task'
 
-def run_prettier(*args)
-  prettier_installed = system('npm', 'ls', 'prettier', '--depth=0', out: File::NULL, err: File::NULL)
-  abort 'prettier is not installed. Run `npm install` before invoking this task.' unless prettier_installed
-
-  sh Shellwords.join(['npm', 'exec', '--', 'prettier', *args])
-end
-
 task default: %i[format lint]
 
 desc 'Lint sources'
@@ -55,7 +48,7 @@ namespace :format do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    run_prettier('--write', '**/*')
+    sh 'npm run fmt'
   end
 end
 
@@ -70,7 +63,7 @@ namespace :fmt do
 
   desc 'Format text, YAML, and Markdown sources with prettier'
   task :text do
-    run_prettier('--write', '**/*')
+    sh 'npm run fmt'
   end
 end
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "prettier": "3.8.1"
   },
   "scripts": {
-    "fmt": "npm run format:text",
-    "format:text": "prettier --write \"**/*\"",
-    "lint:text": "prettier --check \"**/*\""
+    "fmt": "prettier --write \"**/*\""
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "prettier": "3.8.1"
   },
   "scripts": {
-    "fmt": "prettier --write \"**/*\""
+    "fmt": "npm run format:text",
+    "format:text": "prettier --write \"**/*\"",
+    "lint:text": "prettier --check \"**/*\""
   }
 }


### PR DESCRIPTION
## Summary
- revert the repo-specific prettier hardening changes from this branch
- keep the text-formatting paths aligned with the current Artichoke org standard
- route Rake text formatting through `npm run fmt` and keep `package.json` as the source of truth for the prettier command

## Org Consistency
As of March 30, 2026, the common Artichoke pattern in repos such as `raw-parts`, `intaglio`, `rand_mt`, and `sysdir-rs` is:
- CI: `npm ci` followed by `npx prettier --check '**/*'`
- Rake: `npm run fmt`

This PR now matches that pattern.

## Validation
- `npm ci`
- `npx prettier --check '**/*'`
- `bundle exec rake format:text`
- `bundle exec rubocop Rakefile`
- `uv run yamllint --strict --format github .github/workflows/ci.yaml`

Related to #122
