### PR TITLE
ci: remove superfluous rust toolchain actions

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -36,9 +36,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        run: |
+          rustup default stable
+          rustup show
 
       - name: Generate Cargo.lock
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,9 +49,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        run: |
+          rustup default stable
+          rustup show
 
       - name: Generate lockfile
         run: cargo generate-lockfile
@@ -100,9 +100,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: "1.60.0"
+        run: |
+          rustup toolchain install 1.60.0 --profile minimal
+          rustup default 1.60.0
+          rustup show
 
       - name: Generate lockfile
         run: cargo generate-lockfile
@@ -151,9 +152,9 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: stable
+        run: |
+          rustup default stable
+          rustup show
 
       - name: Compile
         run: cargo build --verbose
@@ -199,10 +200,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          components: rustfmt, clippy
-          toolchain: stable
+        run: |
+          rustup default stable
+          rustup component add rustfmt clippy
+          rustup show
 
       - name: Check formatting
         run: cargo fmt --check

--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -40,9 +40,10 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
-        with:
-          toolchain: nightly
+        run: |
+          rustup toolchain install nightly --profile minimal
+          rustup default nightly
+          rustup show
 
       - name: Check docs with no default features
         run: cargo doc --workspace --no-default-features


### PR DESCRIPTION
## Summary

- replace `dtolnay/rust-toolchain` workflow actions with direct `rustup` commands
- preserve stable, MSRV, lint, audit, and nightly rustdoc toolchain selection
- resolve all open `zizmor/superfluous-actions` and `zizmor/ref-version-mismatch` code scanning findings

## Validation

- `mise exec -- npm run fmt:check`
- `mise exec -- uv run yamllint --strict --format github .`
- `mise exec -- uvx zizmor --persona pedantic .`
