### PR TITLE
Add architecture guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,17 +10,20 @@ API. Treat those as compatibility surfaces.
 ## Operating Loop
 
 1. Classify the change before editing.
-2. Use the matching workflow section below to choose the guardrails and runbooks
+2. Read [ARCHITECTURE.md](ARCHITECTURE.md) when the change touches source
+   layout, public API boundaries, Windows FFI, target gates, dependency
+   boundaries, or compatibility surfaces.
+3. Use the matching workflow section below to choose the guardrails and runbooks
    to consult.
-3. Keep the diff narrow. Do not mix behavior, dependency posture, release
+4. Keep the diff narrow. Do not mix behavior, dependency posture, release
    metadata, formatting, platform maintenance, and automation cleanup unless the
    task requires it.
-4. Add or update focused tests for behavior changes, especially changes that
+5. Add or update focused tests for behavior changes, especially changes that
    affect Windows FFI, UTF-16 conversion, pointer ownership, or target gates.
-5. Run checks that match the risk of the change; use
+6. Run checks that match the risk of the change; use
    [CONTRIBUTING.md](CONTRIBUTING.md) for local command expectations. If a
    relevant check is skipped, explain why in the PR.
-6. Update README, crate docs, guardrails, or runbooks when public behavior,
+7. Update README, crate docs, guardrails, or runbooks when public behavior,
    compatibility claims, target support, MSRV, dependency policy, or release
    process changes.
 
@@ -32,6 +35,7 @@ handling.
 
 Consult:
 
+- [Architecture](ARCHITECTURE.md), for the module boundaries and lookup flow.
 - [Platform-specific code](docs/guardrails/platform-specific-code.md), for
   target-gating and platform contract expectations.
 - [FFI and foreign runtime integration](docs/guardrails/ffi-bindings-and-foreign-runtime-integration.md),
@@ -50,6 +54,7 @@ minimum-supported dependency checks.
 
 Consult:
 
+- [Architecture](ARCHITECTURE.md), for the target-specific dependency boundary.
 - [`windows-sys` automation](docs/automations/windows-sys.md), for the expected
   maintenance flow.
 - [API stability, semver, and MSRV](docs/guardrails/api-stability-semver-and-msrv.md),

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,173 @@
+# Architecture
+
+This document is a map of `known-folders-rs`. It should answer where code lives,
+which boundaries matter, and what must stay true when changing the crate.
+
+`known-folders-rs` is intentionally small. It exposes a safe Rust API for
+resolving Windows Known Folder paths with `SHGetKnownFolderPath`. On non-Windows
+targets the crate compiles, but exports no public API.
+
+## Big Picture
+
+```mermaid
+flowchart TD
+    user["Downstream crate"]
+    api["known_folders::{get_known_folder_path, KnownFolder}"]
+    win["src/win.rs<br/>safe Windows wrapper"]
+    ids["src/win/known_folder.rs<br/>KnownFolder enum"]
+    guard["src/win/ffi.rs<br/>CoTaskMemFree guard"]
+    sys["windows-sys"]
+    os["Windows Known Folders API<br/>SHGetKnownFolderPath"]
+
+    user --> api
+    api --> win
+    win --> ids
+    win --> guard
+    win --> sys
+    ids --> sys
+    guard --> sys
+    sys --> os
+```
+
+The important design choice is that raw Windows behavior is contained at one
+boundary. Safe callers pass a `KnownFolder` and receive `Option<PathBuf>`. They
+never receive a raw pointer, allocate a Windows buffer, or decide how to free a
+Windows-owned string.
+
+## Source Layout
+
+- [`src/lib.rs`](src/lib.rs) is the crate boundary. It defines lint policy,
+  crate docs, docs.rs metadata, doctest setup, the Windows target gate, and
+  re-exports the Windows implementation only on Windows.
+- [`src/win.rs`](src/win.rs) is the safe wrapper implementation. It calls
+  `SHGetKnownFolderPath`, handles expected HRESULTs, measures the returned wide
+  string, converts UTF-16 into `OsString`, then returns a `PathBuf`.
+- [`src/win/known_folder.rs`](src/win/known_folder.rs) is the public vocabulary
+  of supported first-party Known Folder IDs. Each enum variant maps to a
+  `windows-sys` `FOLDERID_*` GUID.
+- [`src/win/ffi.rs`](src/win/ffi.rs) owns the narrow FFI helper state. `Guard`
+  stores the `PWSTR` out pointer and frees it with `CoTaskMemFree` on drop.
+- [`examples/get_profile_dir.rs`](examples/get_profile_dir.rs) is the smoke-test
+  example for resolving `KnownFolder::Profile`.
+- [`docs/`](docs/README.md) contains maintenance guardrails, dependency policy,
+  and recurring automation runbooks. It is not user-facing API documentation.
+
+## Public API Boundary
+
+On Windows, the public API is:
+
+- `KnownFolder`, a non-exhaustive enum of first-party Known Folder IDs provided
+  by `windows-sys`.
+- `get_known_folder_path(KnownFolder) -> Option<PathBuf>`, a safe lookup
+  function for the current user.
+
+On non-Windows targets, there are no public items. This is intentional and is a
+compatibility surface. Do not add fallback behavior, environment-variable
+lookups, synthetic paths, or cross-platform abstractions unless the crate's
+public story changes.
+
+```mermaid
+flowchart LR
+    cfg_windows["cfg(windows)"] --> exports["pub use win::*"]
+    cfg_other["not(windows)"] --> empty["empty crate"]
+```
+
+## Lookup Flow
+
+```mermaid
+sequenceDiagram
+    participant Caller
+    participant API as get_known_folder_path
+    participant Guard as ffi::Guard
+    participant Shell as SHGetKnownFolderPath
+    participant Rust as OsString/PathBuf
+
+    Caller->>API: KnownFolder
+    API->>Guard: create null PWSTR holder
+    API->>Shell: GUID, default flags, null token, PWSTR*
+    Shell-->>API: HRESULT and optional PWSTR
+    alt S_OK
+        API->>API: lstrlenW(PWSTR)
+        API->>Rust: OsString::from_wide(slice)
+        API-->>Caller: Some(PathBuf)
+    else expected or unknown failure
+        API-->>Caller: None
+    end
+    API-->>Guard: drop
+    Guard->>Shell: CoTaskMemFree(PWSTR)
+```
+
+The guard is created before the Win32 call and is dropped after the borrowed
+wide slice is no longer used. That order is the core memory-safety invariant in
+the crate.
+
+## FFI Boundary
+
+The wrapper relies on these Windows API contracts:
+
+- `SHGetKnownFolderPath` writes a `PWSTR` out parameter.
+- The returned string is NUL-terminated on success.
+- The caller must free the returned pointer with `CoTaskMemFree` whether the
+  call succeeds or fails.
+- `CoTaskMemFree(NULL)` is allowed and has no effect.
+- `lstrlenW` measures the number of UTF-16 code units before the terminator.
+
+Keep these contracts close to the FFI call. If lookup behavior changes, review:
+
+- pointer initialization and ownership
+- drop order for `ffi::Guard`
+- UTF-16 length calculation
+- conversion through `OsString::from_wide`
+- HRESULT handling
+- 32-bit and 64-bit allocation-size assumptions
+
+## Dependency Boundary
+
+`windows-sys` is target-specific and only enabled for `cfg(windows)`. The
+supported version range is a public maintenance promise, not an implementation
+detail.
+
+Required feature groups are:
+
+- `Win32_Foundation`
+- `Win32_Globalization`
+- `Win32_System_Com`
+- `Win32_UI_Shell`
+
+When changing the range or feature list, use
+[`docs/automations/windows-sys.md`](docs/automations/windows-sys.md) and verify
+the minimum and latest supported versions.
+
+## Compatibility Surfaces
+
+Treat these as user-visible:
+
+- safe lookup behavior for each `KnownFolder` variant
+- collapse of lookup failure into `None`
+- Windows UTF-16 to `PathBuf` conversion
+- `CoTaskMemFree` ownership handling
+- non-Windows empty-crate behavior
+- `windows-sys` supported version range
+- MSRV and edition policy
+- docs.rs target configuration
+- public docs and examples
+
+Changing any of these usually requires README or crate-doc updates and should be
+called out in the PR.
+
+## Making Changes
+
+Use the smallest workflow that matches the change:
+
+- Windows lookup, target gates, UTF-16, pointer ownership, or HRESULT behavior:
+  read the platform, FFI, unsafe-code, and testing guardrails.
+- `KnownFolder` variants or public API shape: read the API stability and
+  platform guardrails.
+- `windows-sys` range or features: read the dependency policy and `windows-sys`
+  automation runbook.
+- Docs-only changes: keep Rust behavior untouched, run text formatting, and
+  explain any skipped Rust checks.
+
+Prefer code that keeps the current architecture obvious: one safe public API,
+one Windows implementation module, one enum vocabulary, one FFI ownership
+helper.


### PR DESCRIPTION
## Summary

- Add a root `ARCHITECTURE.md` that maps the crate's module layout, public API boundary, Windows lookup flow, FFI ownership invariant, dependency boundary, and compatibility surfaces.
- Link the architecture guide from `AGENTS.md` where agents work on source layout, Windows FFI, target gates, and `windows-sys` maintenance.

## Change Class

Documentation-only change.

## Compatibility Impact

No Rust behavior, public API, MSRV, target support, or dependency policy changes. The new document records the existing architecture and compatibility surfaces.

## Validation

- `mise exec -- pnpm run fmt:check`

Rust tests were skipped because this is documentation-only.