### PR TITLE
Update cargo-deny tool pin to 0.19.8

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ node = "24.16.0"
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.25.2"
 
-"cargo:cargo-deny" = "0.19.6"
+"cargo:cargo-deny" = "0.19.8"
 
 [hooks]
 postinstall = "corepack enable"


### PR DESCRIPTION
## Summary
- Change class: Dependencies, CI, and automation.
- Update the `mise.toml` cargo-deny tool pin from `0.19.6` to `0.19.8`.
- Cooldown: `0.19.8` was published on 2026-05-28, more than one week before this sweep on 2026-06-05 UTC.

## Compatibility impact
- No public crate API, Windows FFI, target support, MSRV, or `windows-sys` range changes.
- Keeps the direct development tooling pin exact, matching the repository dependency posture.

## Validation
- `mise install cargo:cargo-deny@0.19.8`
- `mise exec -- cargo-deny --version`
- `mise exec -- cargo-deny --locked --all-features check advisories --show-stats`
- `mise exec -- cargo-deny --locked --all-features check bans licenses sources --show-stats`