### PR TITLE
Update pnpm package manager pin to 11.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d",
+  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",


### PR DESCRIPTION
## Summary
- Change class: Dependencies, CI, and automation.
- Update `package.json#packageManager` from `pnpm@11.1.3` to `pnpm@11.5.0` with Corepack's integrity hash.
- `pnpm-lock.yaml` did not change after the package-manager refresh.
- Cooldown: `11.5.0` was published on 2026-05-29T15:35:17Z, more than one week before this sweep on 2026-06-05T23:04:00Z. `11.5.1` and `11.5.2` were intentionally skipped because they are still inside the cooldown window.

## Compatibility impact
- No public crate API, Windows FFI, target support, MSRV, or `windows-sys` range changes.
- Keeps package-manager selection exact and Corepack-managed, matching the repository dependency posture.

## Validation
- `COREPACK_HOME=/private/tmp/known-folders-corepack mise exec -- corepack use pnpm@11.5.0`
- `COREPACK_HOME=/private/tmp/known-folders-corepack mise exec -- pnpm --version`
- `COREPACK_HOME=/private/tmp/known-folders-corepack mise exec -- pnpm install --frozen-lockfile`
- `COREPACK_HOME=/private/tmp/known-folders-corepack mise exec -- pnpm run fmt:check`