### PR TITLE
Update dependency sweep tool pins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,7 @@ jobs:
       - name: Setup Node.js runtime
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.16.0"
+          node-version: "24.18.0"
           cache: pnpm
 
       - name: Install pnpm dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -1,10 +1,10 @@
 [tools]
-node = "24.16.0"
+node = "24.18.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.25.2"
+zizmor = "1.26.1"
 
-"cargo:cargo-deny" = "0.19.8"
+"cargo:cargo-deny" = "0.19.9"
 
 [hooks]
 postinstall = "corepack enable"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.5.0+sha512.dbfcc4f81cf48597afd4bc391ffdf12c11f1a9fb83a395bfa6b0a2d9cc2fd8ffebafdb1ccbd529632153f793904c2615b7f09fe1a345473fd1c35845172a8eb1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",


### PR DESCRIPTION
## Summary

- update Node.js from 24.16.0 to 24.18.0 in `mise.toml` and CI text-formatting setup
- update `package.json#packageManager` from pnpm 11.5.0 to pnpm 11.9.0 using Corepack
- update local development tool pins: `zizmor` 1.25.2 to 1.26.1 and `cargo-deny` 0.19.8 to 0.19.9

## Change class

Dependencies, CI, and automation maintenance.

## Compatibility impact

No public crate API, Windows FFI, target-gating, MSRV, or `windows-sys` compatibility changes. This only updates local/CI development tooling pins.

## Upstream review and cooldown

- Node.js 24.18.0 is the latest LTS release in the 24.x line; upstream release date: 2026-06-23.
- pnpm 11.9.0 is the npm `latest` release; upstream publish date: 2026-06-23.
- zizmor 1.26.1 is the latest PyPI release; upstream upload date: 2026-06-21.
- cargo-deny 0.19.9 is the latest crates.io release; upstream publish date: 2026-06-15.

All adopted versions are outside the repository's one-week cooldown as of 2026-07-01.

## Validation

- `mise exec -- env CI=true COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store corepack pnpm install --frozen-lockfile`
- `mise exec -- env COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store corepack pnpm run fmt:check`
- `mise exec -- zizmor --persona=pedantic .github/workflows`
- `mise exec -- cargo deny --locked --all-features check`

Note: `cargo deny check --locked --all-features` was tried first and rejected because the local CLI expects global options before `check`; the corrected command above passed.