### PR TITLE
chore(deps): run zizmor action from mise pin

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -63,7 +63,19 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Resolve zizmor version
+        id: zizmor-version
+        shell: bash
+        run: |
+          version="$(awk -F '"' '/^[[:space:]]*zizmor[[:space:]]*=/{ print $2; exit }' mise.toml)"
+          if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            echo "Unable to resolve exact zizmor version from mise.toml" >&2
+            exit 1
+          fi
+          printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
+
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
         with:
           persona: "pedantic"
+          version: ${{ steps.zizmor-version.outputs.version }}


### PR DESCRIPTION
## Summary

- resolve the zizmor CLI version from `mise.toml` in the audit workflow
- pass the resolved version to `zizmorcore/zizmor-action`
- keep the existing canonical `mise.toml` zizmor pin and current action version aligned

## Change Class

Dependencies, CI, and automation.

## Compatibility Impact

CI/tooling only. This does not change the public crate API, runtime behavior, platform lookup behavior, MSRV, or release metadata.

## Validation

- `awk` extraction resolves `version=1.26.1` and rejects non-exact versions
- `git diff --check`
- `mise exec -- pnpm exec prettier --check .github/workflows/audit.yaml mise.toml`
- `mise exec -- zizmor --pedantic --no-progress --cache-dir /private/tmp/... .github/workflows/audit.yaml`

Rust tests were not run because this only changes audit workflow/tool pinning.