### PR TITLE
Update dependency tooling pins

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@ node = "24.18.0"
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.26.1"
 
-"cargo:cargo-deny" = "0.19.9"
+"cargo:cargo-deny" = "0.20.2"
 
 [hooks]
 postinstall = "corepack enable"

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
+  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",
   "devDependencies": {
-    "prettier": "3.8.4"
+    "prettier": "3.9.5"
   },
   "scripts": {
     "fmt": "prettier --write \"**/*\"",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     devDependencies:
       prettier:
-        specifier: 3.8.4
-        version: 3.8.4
+        specifier: 3.9.5
+        version: 3.9.5
 
 packages:
 
-  prettier@3.8.4:
-    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+  prettier@3.9.5:
+    resolution: {integrity: sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==}
     engines: {node: '>=14'}
     hasBin: true
 
 snapshots:
 
-  prettier@3.8.4: {}
+  prettier@3.9.5: {}


### PR DESCRIPTION
## Summary

Change class: Dependencies, CI, and automation maintenance.

Compatibility impact: no public Rust API, Windows FFI, target-gating, MSRV, or `windows-sys` compatibility change. This only updates development tooling pins and the generated pnpm lockfile.

- Bump `packageManager` from pnpm 11.9.0 to 11.11.0.
- Bump Prettier from 3.8.4 to 3.9.5 and refresh `pnpm-lock.yaml` with pnpm 11.11.0.
- Bump local `cargo:cargo-deny` from 0.19.9 to 0.20.2.

## Dependency review

No open Dependabot PRs were present at sweep time.

Reviewed upstream metadata and compares:

- pnpm 11.9.0 -> 11.11.0: https://github.com/pnpm/pnpm/compare/v11.9.0...v11.11.0
- Prettier 3.8.4 -> 3.9.5: https://github.com/prettier/prettier/compare/3.8.4...3.9.5
- cargo-deny 0.19.9 -> 0.20.2: https://github.com/EmbarkStudios/cargo-deny/compare/0.19.9...0.20.2

Risk classification: moderate for the sweep as a whole. pnpm and cargo-deny include security and CLI behavior changes, but both are development tooling only in this crate. pnpm 11.11.0 requires Node >=22.13 and is compatible with the repository's Node 24.18.0 pin. cargo-deny 0.20.2 moves `--locked` and `--all-features` to root-level CLI options; the pinned GitHub Action already passes `arguments` before `check`, and local validation used the new order.

Cooldown decisions: adopted only releases older than the one-week cutoff at 2026-07-10T00:14:07Z. Deferred pnpm 11.12.0, pnpm 11.13.x, and zizmor 1.27.0 because they were still inside cooldown. Node 24.18.0 was already the latest LTS release older than the cutoff.

## Validation

- `COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store mise exec -- pnpm install --lockfile-only`
- `CI=true COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store mise exec -- pnpm install --frozen-lockfile`
- `COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store mise exec -- pnpm run fmt`
- `COREPACK_HOME=/private/tmp/known-folders-rs-corepack PNPM_HOME=/private/tmp/known-folders-rs-pnpm-home PNPM_STORE_DIR=/private/tmp/known-folders-rs-pnpm-store mise exec -- pnpm run fmt:check`
- `cargo fmt --check`
- `mise exec -- cargo-deny --locked --all-features check advisories bans licenses sources --show-stats`
- `cargo test --workspace`