### PR TITLE
Update pnpm to 11.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.12.0+sha512.820a6fbd0d9f04c226638002aead1e45340a9139dd5dc077c1d83ef44aa2481c8eb6637b4c9aa696a3c7e35ba818e49cf27213e5f2b91138d09b7a3e26e898ba",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",


### PR DESCRIPTION
## Summary

Update the Corepack-selected pnpm pin from 11.11.0 to 11.12.0, including the exact registry integrity hash. The pnpm lockfile is unchanged after regeneration.

Change class: dependency tooling maintenance. Compatibility impact: none for the crate API, Rust dependencies, MSRV, or target support.

## Upstream review

Reviewed the authoritative [pnpm 11.12 release](https://github.com/pnpm/pnpm/releases/tag/v11.12.0) and [v11.11.0...v11.12.0 compare](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.12.0). The published package preserves the Node `>=22.13` engine requirement and executable layout. Relevant changes are additive or corrective around install, peer resolution, local dependency handling, and command behavior. Risk classification: low for this repository's install-and-format-only pnpm usage.

## Cooldown

The sweep used a cutoff of 2026-07-13T21:08:04Z. pnpm 11.12.0 was published on 2026-07-11 and is eligible. Newer pnpm 11.13.x through 11.15.1 and Zizmor 1.27.0 remain inside the one-week cooldown. Node 24.18.0 and cargo-deny 0.20.2 remain current.

## Validation

- `pnpm --version` (11.12.0)
- `pnpm install --lockfile-only`
- `pnpm install --frozen-lockfile`
- `pnpm run fmt`
- `pnpm run fmt:check`
- `cargo fmt --check`
- `cargo deny --all-features check advisories bans licenses sources --show-stats`
- `cargo test --workspace`
- `git diff --check`

All checks passed.