### PR TITLE
Update pnpm to 11.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.11.0+sha512.4463f65fd80ed80d69bc1d4bf163ee94f605c7380fc318bb5b2ebe15f8cd12d49c51a4d59e951b401e764d3b6ca751cbf51bc50ed7001a6bcb4935e684c34882",
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",


### PR DESCRIPTION
## Summary

Update the Corepack-selected pnpm pin from 11.11.0 to 11.15.1, including the exact registry integrity hash. The pnpm lockfile is unchanged after regeneration.

Change class: dependency tooling maintenance. Compatibility impact: none for the crate API, Rust dependencies, MSRV, or target support.

## Upstream review

Reviewed the authoritative [pnpm 11.12.0 through 11.15.1 releases](https://github.com/pnpm/pnpm/releases/tag/v11.15.1), the [v11.11.0...v11.15.1 upstream compare](https://github.com/pnpm/pnpm/compare/v11.11.0...v11.15.1), npm package metadata, signature, and SLSA provenance.

The published package preserves the Node `>=22.13` engine requirement and executable layout. The upstream range contains 188 commits, including additive package-manager features and install/resolution fixes; repository exposure is limited to frozen installation and running Prettier. Relevant release hardening verifies published tarballs, rejects known-broken pnpm releases, and smoke-tests self-updated binaries. The exact `pnpm/action-setup` bootstrap path—pnpm 11.7.0 self-updating to 11.15.1—also passed locally. Risk classification: moderate upstream scope, low exposure for this repository.

pnpm 11.12.0 and 11.13.0 remain deprecated in the npm registry as broken. This update skips both and adopts a non-deprecated corrective release newer than the upstream-recommended 11.13.1 floor.

## Cooldown

The sweep used a cutoff of 2026-07-20T18:02:33Z. pnpm 11.15.1 was published on 2026-07-19 and is cooldown-eligible. pnpm 11.16.0 and 11.17.0 remain inside the one-week cooldown.

Zizmor 1.27.0 was not adopted because 1.28.0 disclosed that 1.27.0 could log configured GitHub credentials in cleartext. The fixed 1.28.0 release is still inside cooldown. Node 24.18.0 and cargo-deny 0.20.2 remain current.

## Validation

- `mise exec -- pnpm --version` (11.15.1)
- `mise exec -- pnpm install --lockfile-only`
- `mise exec -- pnpm install --frozen-lockfile`
- `mise exec -- pnpm run fmt`
- `mise exec -- pnpm run fmt:check`
- `mise exec -- cargo fmt --check`
- `mise exec -- cargo deny --all-features check advisories bans licenses sources --show-stats`
- `mise exec -- cargo test --workspace`
- `git diff --check`

All checks passed.