### PR TITLE
Update Node.js and pnpm

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "24.18.0"
+          node-version: "24.19.0"
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,7 +235,7 @@ jobs:
       - name: Setup Node.js runtime
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "24.18.0"
+          node-version: "24.19.0"
           cache: pnpm
 
       - name: Install pnpm dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "24.18.0"
+node = "24.19.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
 zizmor = "1.26.1"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "windows"
   ],
   "repository": "github:artichoke/known-folders-rs",
-  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065",
+  "packageManager": "pnpm@11.20.0+sha512.9a6f330a95b66446ea088faf1521405a8a01f07fde7124cc9958dfed52d4bb436737e65b08f85f37b46fcba375092558ac51262b816844b22f63406ed166bfee",
   "author": "Ryan Lopopolo <rjl@hyperbo.la> (https://hyperbo.la/)",
   "homepage": "https://www.artichokeruby.org",
   "bugs": "https://github.com/artichoke/known-folders-rs/issues",


### PR DESCRIPTION
## Summary

Update the repository JavaScript toolchain pins:

- Node.js 24.18.0 → 24.19.0 in `mise.toml` and CI
- pnpm 11.15.1 → 11.20.0 in `package.json`, including the exact npm SHA-512 digest

This is routine dependency maintenance under [`docs/automations/dependency-sweep.md`](https://github.com/artichoke/known-folders-rs/blob/trunk/docs/automations/dependency-sweep.md).

## Upstream review and risk

Reviewed the authoritative release metadata and upstream compares:

- [Node.js v24.18.0...v24.19.0](https://github.com/nodejs/node/compare/v24.18.0...v24.19.0)
- [pnpm v11.15.1...v11.20.0](https://github.com/pnpm/pnpm/compare/v11.15.1...v11.20.0)
- [pnpm 11.20.0 release](https://github.com/pnpm/pnpm/releases/tag/v11.20.0)

The upstream scope is moderate, but repository exposure is low: Node and pnpm only bootstrap the frozen formatting dependency set and run Prettier. pnpm 11.20.0 preserves Node `>=22.13`, retains the package executable layout, is not deprecated, and carries npm registry signatures and SLSA provenance. Its release also adds package-substitution and rebuild path-traversal hardening. This repository does not configure `namedRegistries`, so the semi-breaking lockfile re-keying path is not exercised.

Both releases cleared the one-week cooldown at the 2026-08-10 sweep cutoff. pnpm 11.21.0 remains inside cooldown and was deferred.

## Compatibility impact

No Rust dependency, public API, MSRV, Windows target behavior, or published crate metadata changes. The pnpm lockfile is unchanged after regeneration.

## Validation

- `mise exec -- node --version` (v24.19.0)
- `mise exec -- pnpm --version` (11.20.0)
- `mise exec -- pnpm install --lockfile-only`
- `mise exec -- pnpm install --frozen-lockfile`
- `mise exec -- pnpm run fmt`
- `mise exec -- pnpm run fmt:check`
- `mise exec -- cargo fmt --check`
- `mise exec -- cargo deny --all-features check advisories bans licenses sources --show-stats`
- `mise exec -- cargo test --workspace`
- `git diff --check`
