### PR TITLE
Update Zizmor and zizmor-action

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -166,7 +166,7 @@ jobs:
           printf 'version=%s\n' "${version}" >> "${GITHUB_OUTPUT}"
 
       - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           persona: "pedantic"
           version: ${{ steps.zizmor-version.outputs.version }}

--- a/mise.toml
+++ b/mise.toml
@@ -2,7 +2,7 @@
 node = "24.19.0"
 # Rust intentionally tracks the stable channel for this Rust library.
 rust = { version = "stable", profile = "minimal", components = "clippy,rustfmt" }
-zizmor = "1.26.1"
+zizmor = "1.29.0"
 
 "cargo:cargo-deny" = "0.20.2"
 


### PR DESCRIPTION
## Summary

Update the matching Zizmor tool and GitHub Action pins:

- Zizmor 1.26.1 → 1.29.0 in `mise.toml`
- `zizmorcore/zizmor-action` v0.6.1 → v0.6.2 at immutable commit `3dc1ecc9bcb9e94e9b2c709687979e1298497054`

This is routine dependency maintenance under [`docs/automations/dependency-sweep.md`](https://github.com/artichoke/known-folders-rs/blob/trunk/docs/automations/dependency-sweep.md). The action update is included with maintainer approval because v0.6.1 does not recognize Zizmor 1.29.0.

## Upstream review and risk

Reviewed authoritative release metadata and upstream compares:

- [Zizmor v1.26.1...v1.29.0](https://github.com/zizmorcore/zizmor/compare/v1.26.1...v1.29.0)
- [`zizmor-action` v0.6.1...v0.6.2](https://github.com/zizmorcore/zizmor-action/compare/v0.6.1...v0.6.2)
- [`zizmor-action` v0.6.2 release](https://github.com/zizmorcore/zizmor-action/releases/tag/v0.6.2)

The upstream Zizmor scope is moderate, but repository exposure is low: this repository runs it only as a GitHub Actions workflow auditor with the pedantic persona. Zizmor 1.29.0 retains `--pedantic`, and this repository does not use the removed `--collect=workflows-only` or `--collect=actions-only` aliases.

Action v0.6.2 is the compatibility companion release: it adds the verified 1.29.0 image digest and makes 1.29.0 the default. The first CI run demonstrated the exact mismatch in v0.6.1 with `Unknown version: 1.29.0`.

Zizmor 1.27.0 had a credential-logging defect; 1.28.0 fixed it, and 1.29.0 is unaffected. Both 1.29.0 and action v0.6.2 were published on 2026-08-01 and cleared the one-week cooldown.

## Compatibility impact

No Rust dependency, public API, MSRV, Windows target behavior, workflow permissions, or published crate metadata changes.

## Validation

- `mise exec -- node --version` (v24.19.0)
- `mise exec -- pnpm --version` (11.20.0)
- `mise exec -- pnpm install --frozen-lockfile`
- `mise exec -- pnpm run fmt`
- `mise exec -- pnpm run fmt:check`
- `mise exec -- zizmor --version` (1.29.0)
- `mise exec -- zizmor --pedantic .` (no findings; offline local mode)
- `mise exec -- cargo fmt --check`
- `mise exec -- cargo deny --all-features check advisories bans licenses sources --show-stats`
- `mise exec -- cargo test --workspace`
- `git diff --check`
